### PR TITLE
Added Providers property to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `Providers` property to config
+
 ## [0.0.5] - 2024-03-04
 
 ### Removed

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,9 +9,10 @@ import (
 
 // TestConfig provides a standard configuration for Apps
 type TestConfig struct {
-	AppName    string `json:"appName"`
-	RepoName   string `json:"repoName"`
-	AppCatalog string `json:"appCatalog"`
+	AppName    string   `json:"appName"`
+	RepoName   string   `json:"repoName"`
+	AppCatalog string   `json:"appCatalog"`
+	Providers  []string `json:"providers"`
 }
 
 // MustLoad opens the given yaml file and parses it into a TestConfig instance


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3268

Added a `Providers` property that is used to indicate what CAPI providers to test against