### PR TITLE
Handle cluster creation / deletion in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+### Added
+
+- Workload Cluster creation and deletion is now handled in code using `cluster-standup-teardown`
 
 ## [0.0.7] - 2024-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Workload Cluster creation and deletion is now handled in code using `cluster-standup-teardown`
 
+### Changed
+
+- Change `BeforeInstall` hook to be `AfterClusterReady` as wouldn't make sense for default apps that are installed as part of the cluster creation
+
 ## [0.0.7] - 2024-04-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Before you can run tests locally you must set the following required environment
 - `E2E_KUBECONFIG_CONTEXT` must be set to the context to use for the management cluster in the kubeconfig (e.g. `capa`)
 - `E2E_APP_VERSION` must be set to version of the app to test against (e.g. `3.5.1`). Note, this version must have already been published to the catalog.
 
+Optionally, the following can be set to re-use an existing workload cluster:
+
+- `E2E_WC_NAME` - the name of the workload cluster on the MC
+- `E2E_WC_NAMESPACE` - the namespace the workload cluser is found in
+
 Once those are set, you can trigger the E2E tests in you App repo with the following:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A test framework for helping with E2E testing of Giant Swarm managed Apps within
 ## Features
 
 - Handles test suite setup (using Ginkgo)
+- Handles workload cluster creation and deletion
 - Provides shared state across test cases
 - Provides hooks for pre-install, pre-upgrade and post-install steps
 
@@ -93,12 +94,10 @@ If you want to trigger the test suites against only a single provider (rather th
 > [!NOTE]
 > Make sure you have [Ginkgo installed](https://onsi.github.io/ginkgo/#installing-ginkgo)
 
-Before you can run tests locally you must have already created a CAPI workload cluster and then set the following required environment variables:
+Before you can run tests locally you must set the following required environment variables:
 
-- `E2E_KUBECONFIG` must be set to the path to the kubeconfig of the test management cluster (e.g. `./kube/e2e.yaml`)
+- `E2E_KUBECONFIG` must be set to the path to the kubeconfig of the test management cluster (e.g. `./kube/e2e.yaml`) - for the requirements of this kubeconfig please see [cluster-standup-teardown](https://github.com/giantswarm/cluster-standup-teardown) for more details.
 - `E2E_KUBECONFIG_CONTEXT` must be set to the context to use for the management cluster in the kubeconfig (e.g. `capa`)
-- `E2E_WC_NAME` must be set to the name of the test workload cluster (e.g. `t-e5u0tg00n2g36xt8xa`)
-- `E2E_WC_NAMESPACE` must be set to namespace the test workload cluster is in within the management cluster (e.g. `org-t-pjii9jvrbzlasxpow6`)
 - `E2E_APP_VERSION` must be set to version of the app to test against (e.g. `3.5.1`). Note, this version must have already been published to the catalog.
 
 Once those are set, you can trigger the E2E tests in you App repo with the following:
@@ -109,6 +108,14 @@ ginkgo --timeout 4h -v -r ./suites/basic/
 ```
 
 This will run the `basic` test suite. If you have others you wish to run, replace the directory with the test suite you want to trigger.
+
+### Running local `apptest-framework` changes
+
+If you need to run with a local copy of `apptest-framework` (such as when testing out changes to the framework) you can do so by adding the following to your Apps test go.mod (with the path correctly set to point to your checked out code):
+
+```
+replace github.com/giantswarm/apptest-framework => /path/to/my/apptest-framework
+```
 
 ## API Documentation
 
@@ -138,4 +145,5 @@ To add a new test suite, create a new directory under `./tests/e2e/suites/` with
 
 - [Ginkgo docs](https://onsi.github.io/ginkgo/)
 - [`clustertest` documentation](https://pkg.go.dev/github.com/giantswarm/clustertest)
+- [`cluster-standup-teardown`](https://github.com/giantswarm/cluster-standup-teardown)
 - [CI Tekton Pipeline](https://github.com/giantswarm/tekton-resources/blob/main/tekton-resources/pipelines/app-test-suites.yaml)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.21
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280
 
 require (
-	github.com/giantswarm/apiextensions-application v0.6.0
+	github.com/giantswarm/apiextensions-application v0.6.1
+	github.com/giantswarm/cluster-standup-teardown v1.0.2
 	github.com/giantswarm/clustertest v0.18.0
 	github.com/onsi/ginkgo/v2 v2.17.2
 	github.com/onsi/gomega v1.33.1
@@ -15,6 +16,7 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v1.2.1 // indirect
@@ -123,7 +125,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.10.0 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
-	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 h1:EKPd1INOIyr5hWOWhvpmQpY6tKjeG0hT1s3AMC/9fic=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=
@@ -140,7 +142,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -209,8 +211,10 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/giantswarm/apiextensions-application v0.6.0 h1:ZPIiq27zJ2VatrWH21/dK6jR9rJrr4VJUP/Fo0GvsPE=
-github.com/giantswarm/apiextensions-application v0.6.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
+github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
+github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
+github.com/giantswarm/cluster-standup-teardown v1.0.2 h1:+5wL7Pt/zlH1R7e1yu/ze2LgYUJTx3VmWv+9u7k8D/w=
+github.com/giantswarm/cluster-standup-teardown v1.0.2/go.mod h1:hREsAWG9OVP/wMiLdiNx1koWdC4XUsg0tPt8Zz1gf2o=
 github.com/giantswarm/clustertest v0.18.0 h1:OeiRuM3aOSzH/LzoS0FvsF8aGggc7BuRQOTB6wa+ToM=
 github.com/giantswarm/clustertest v0.18.0/go.mod h1:/lKOF0DBZs9ln8CXiq/gqIQL/rUBGXDiWHb+Q0QNlMk=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
@@ -650,8 +654,8 @@ github.com/spf13/cast v1.5.1/go.mod h1:b9PdjNptOpzXr7Rq1q9gJML/2cdGQAo69NKzQ10KN
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
-github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
-github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -137,8 +137,8 @@ func (s *suite) Run(t *testing.T, suiteName string) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cb).NotTo(BeNil())
 
-		// Use ClusterBuilder to create a new cluster with all default values
-		cluster := cb.NewClusterApp("", "", []string{}, []string{})
+		// Load an existing cluster is env vars are set, otherwise create a new cluster
+		cluster := clusterbuilder.LoadOrBuildCluster(state.GetFramework(), cb)
 		Expect(cluster).NotTo(BeNil())
 		state.SetCluster(cluster)
 

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -11,15 +11,22 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/apptest-framework/pkg/client"
 	"github.com/giantswarm/apptest-framework/pkg/config"
 	"github.com/giantswarm/apptest-framework/pkg/state"
+	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder"
+	"github.com/giantswarm/cluster-standup-teardown/pkg/standup"
+	"github.com/giantswarm/cluster-standup-teardown/pkg/teardown"
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
+	clusterclient "github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -112,15 +119,11 @@ func (s *suite) Run(t *testing.T, suiteName string) {
 
 		mcKubeconfig := os.Getenv("E2E_KUBECONFIG")
 		mcContext := os.Getenv("E2E_KUBECONFIG_CONTEXT")
-		wcName := os.Getenv("E2E_WC_NAME")
-		wcNamespace := os.Getenv("E2E_WC_NAMESPACE")
 		appVersion := os.Getenv("E2E_APP_VERSION")
 
 		// Ensure all require env vars are set
 		Expect(mcKubeconfig).ToNot(BeEmpty(), "`E2E_KUBECONFIG` must be set to the kubeconfig of the test MC")
 		Expect(mcContext).ToNot(BeEmpty(), "`E2E_KUBECONFIG_CONTEXT` must be set to the context to use in the kubeconfig")
-		Expect(wcName).ToNot(BeEmpty(), "`E2E_WC_NAME` must be set to the name of the test WC")
-		Expect(wcNamespace).ToNot(BeEmpty(), "`E2E_WC_NAMESPACE` must be set to namespace the test WC is in")
 		Expect(appVersion).ToNot(BeEmpty(), "`E2E_APP_VERSION` must be set to version of the app to test against")
 
 		state.SetContext(context.Background())
@@ -130,11 +133,75 @@ func (s *suite) Run(t *testing.T, suiteName string) {
 		Expect(err).NotTo(HaveOccurred())
 		state.SetFramework(framework)
 
-		// Setup client for connecting to WC
-		cluster, err := framework.LoadCluster()
+		cb, err := clusterbuilder.GetClusterBuilderForContext(mcContext)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cb).NotTo(BeNil())
+
+		// Use ClusterBuilder to create a new cluster with all default values
+		cluster := cb.NewClusterApp("", "", []string{}, []string{})
+		Expect(cluster).NotTo(BeNil())
+		state.SetCluster(cluster)
+
+		// Create new workload cluster
+		logger.Log("Creating new workload cluster")
+
+		// We want to make sure the cluster is ready enough for us to install a new App
+		// so we wait for all control plane nodes and at least 2 workers to be ready
+		clusterReadyFns := []func(wcClient *clusterclient.Client){
+			func(wcClient *clusterclient.Client) {
+				replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
+				Expect(err).NotTo(HaveOccurred())
+
+				// Only check for control plane if not a managed cluster (e.g. EKS)
+				if replicas != 0 {
+					logger.Log("Waiting for %q control plane nodes to be ready", replicas)
+					_ = wait.For(
+						wait.AreNumNodesReady(context.Background(), wcClient, 3, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}),
+						wait.WithTimeout(20*time.Minute),
+						wait.WithInterval(15*time.Second),
+					)
+				}
+			},
+			func(wcClient *clusterclient.Client) {
+				logger.Log("Waiting for worker nodes to be ready")
+				_ = wait.For(
+					wait.AreNumNodesReady(context.Background(), wcClient, 2, &cr.MatchingLabels{"node-role.kubernetes.io/worker": ""}),
+					wait.WithTimeout(20*time.Minute),
+					wait.WithInterval(15*time.Second),
+				)
+			},
+			func(wcClient *clusterclient.Client) {
+				logger.Log("Waiting for all default apps to be ready")
+				defaultAppsAppName := fmt.Sprintf("%s-%s", state.GetCluster().Name, "default-apps")
+
+				Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace())).
+					WithTimeout(30 * time.Second).
+					WithPolling(50 * time.Millisecond).
+					Should(BeTrue())
+
+				// Wait for all default-apps apps to be deployed
+				appList := &v1alpha1.AppList{}
+				err := state.GetFramework().MC().List(state.GetContext(), appList, cr.InNamespace(state.GetCluster().Organization.GetNamespace()), cr.MatchingLabels{"giantswarm.io/managed-by": defaultAppsAppName})
+				Expect(err).NotTo(HaveOccurred())
+
+				appNamespacedNames := []types.NamespacedName{}
+				for _, app := range appList.Items {
+					appNamespacedNames = append(appNamespacedNames, types.NamespacedName{Name: app.Name, Namespace: app.Namespace})
+				}
+
+				Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
+					WithTimeout(15 * time.Minute).
+					WithPolling(10 * time.Second).
+					Should(BeTrue())
+			},
+		}
+
+		cluster, err = standup.New(state.GetFramework(), false, clusterReadyFns...).Standup(cluster)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cluster).NotTo(BeNil())
 		state.SetCluster(cluster)
+
+		logger.Log("Workload cluster ready to use")
 
 		// Create app
 		app := application.New(fmt.Sprintf("%s-%s", cluster.Name, s.appName), s.appName).
@@ -154,6 +221,10 @@ func (s *suite) Run(t *testing.T, suiteName string) {
 		app := state.GetApplication()
 		logger.Log("Uninstalling App %s", app.AppName)
 		err := state.GetFramework().MC().DeleteApp(state.GetContext(), *app)
+		Expect(err).NotTo(HaveOccurred())
+
+		logger.Log("Deleting workload cluster")
+		err = teardown.New(state.GetFramework()).Teardown(state.GetCluster())
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/30662

This PR switches to using [cluster-standup-teardown](https://github.com/giantswarm/cluster-standup-teardown) to handle the creation and deletion of the workload cluster within the test framework rather than requiring one to be pre-created.

This also changes the `BeforeInstall` hook to be `AfterClusterReady` so it makes more sense when running against defaults apps.