### PR TITLE
Fix check for control plane replicas to not use hard coded value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check for defined number of control plane replicas instead of hardcoded to 3.
+
 ## [1.0.0] - 2024-04-30
 
 ### Added

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -156,7 +156,7 @@ func (s *suite) Run(t *testing.T, suiteName string) {
 				if replicas != 0 {
 					logger.Log("Waiting for %q control plane nodes to be ready", replicas)
 					_ = wait.For(
-						wait.AreNumNodesReady(context.Background(), wcClient, 3, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}),
+						wait.AreNumNodesReady(context.Background(), wcClient, int(replicas), &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}),
 						wait.WithTimeout(20*time.Minute),
 						wait.WithInterval(15*time.Second),
 					)


### PR DESCRIPTION
Looks like we didn't actually make use of the `replicas` that we checked for 🤦  This fixes that oversight but shouldn't have any impact as we currently only support either managed control plane or 3 replicas.