### PR TITLE
Enable JSON test reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable JSON output for test results.
+
 ## [1.11.0] - 2025-01-21
 
 ### Changed

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,4 @@ mkdir -p ${REPORT_DIR}
 echo "Test results will be saved to: ${REPORT_DIR}"
 
 echo "🛠️ Building test suites... (this may take a short while with no log output)"
-ginkgo --output-dir=${REPORT_DIR} --junit-report=test-results.xml --timeout 4h --keep-going -v -r $@ ${SUITES_TO_RUN}
+ginkgo --output-dir=${REPORT_DIR} --junit-report=test-results.xml --json-report=test-results.json --timeout 4h --keep-going -v -r $@ ${SUITES_TO_RUN}


### PR DESCRIPTION
### What this PR does / why we need it

- Enable JSON test reports for https://github.com/giantswarm/tekton-resources/pull/507

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run app-test-suites
