### PR TITLE
Added retry logic when checking if MC is ephemeral or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added retry logic when checking if MC is ephemeral or not
+
 ## [1.15.0] - 2025-08-13
 
 ### Changed

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -487,10 +487,12 @@ func getInstallApp() *application.Application {
 func isEphemeralTestMC() bool {
 	values := &application.ClusterValues{}
 
+	clusterName := cleanClusterName(state.GetFramework().MC().GetClusterName())
 	// It's possible that we connect to an MC while it is still being set up and not quite ready yet.
 	// If we get an error while trying to get the Cluster values we'll retry for up to 2 minutes
 	Eventually(func() error {
-		return state.GetFramework().MC().GetHelmValues(cleanClusterName(state.GetFramework().MC().GetClusterName()), "org-giantswarm", values)
+		logger.Log("Checking if MC '%s' is ephemeral", clusterName)
+		return state.GetFramework().MC().GetHelmValues(clusterName, "org-giantswarm", values)
 	}).
 		WithTimeout(2 * time.Minute).
 		WithPolling(5 * time.Second).


### PR DESCRIPTION
### What this PR does / why we need it

Sometimes the MC isn't quite ready to be used even if it's "running" so we add some retry logic if we encounter an error.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run app-test-suites
