### PR TITLE
fix: install basic suite hello-world via HelmRelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `basic` e2e suite: install the `hello-world` test app via a Flux `HelmRelease` instead of an `App` CR. The App CR path injects the cluster-values, which `hello-world` v3.x rejects (`additionalProperties: false` at the schema root) with a `values-schema-violation`, so the install never completed. This mirrors how `cluster-test-suites` installs `hello-world`.
+- `basic` e2e suite: retry the workload cluster connection check to tolerate the WC API DNS record not being resolvable immediately after the cluster becomes ready.
+
 ## [5.0.1] - 2026-05-08
 
 ### Changed

--- a/tests/e2e/suites/basic/basic_suite_test.go
+++ b/tests/e2e/suites/basic/basic_suite_test.go
@@ -21,11 +21,20 @@ const (
 
 func TestBasic(t *testing.T) {
 	installNamespace := "default"
+	// hello-world is installed via a Flux HelmRelease (not an App CR) so that the
+	// platform's cluster-values aren't injected into the chart. hello-world v3.x
+	// sets `additionalProperties: false` at the schema root and would otherwise
+	// fail to install with a values-schema-violation. This mirrors how
+	// cluster-test-suites installs hello-world.
+	releaseName := "hello-world"
 
 	suite.New().
 		WithInstallNamespace(installNamespace).
 		WithIsUpgrade(isUpgrade).
 		WithValuesFile("./values.yaml").
+		WithHelmRelease(true).
+		WithHelmReleaseName(releaseName).
+		WithHelmTargetNamespace(installNamespace).
 		AfterClusterReady(func() {
 
 			It("should connect to the management cluster", func() {
@@ -34,11 +43,18 @@ func TestBasic(t *testing.T) {
 			})
 
 			It("should connect to the workload cluster", func() {
-				wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = wcClient.CheckConnection()
-				Expect(err).NotTo(HaveOccurred())
+				// Retry to tolerate the workload cluster API DNS record not yet
+				// being resolvable immediately after the cluster is ready.
+				Eventually(func() error {
+					wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+					if err != nil {
+						return err
+					}
+					return wcClient.CheckConnection()
+				}).
+					WithPolling(10 * time.Second).
+					WithTimeout(5 * time.Minute).
+					ShouldNot(HaveOccurred())
 			})
 
 		}).
@@ -59,7 +75,7 @@ func TestBasic(t *testing.T) {
 				Eventually(func() error {
 					logger.Log("Checking if deployment exists in the workload cluster")
 					var dp appsv1.Deployment
-					err := wcClient.Get(state.GetContext(), types.NamespacedName{Namespace: installNamespace, Name: state.GetApplication().AppName}, &dp)
+					err := wcClient.Get(state.GetContext(), types.NamespacedName{Namespace: installNamespace, Name: releaseName}, &dp)
 					if err != nil {
 						logger.Log("Failed to get deployment: %v", err)
 					}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36860

The `basic` e2e suite installed `hello-world` through an App CR, which makes the platform inject the cluster-values into the chart. `hello-world` v3.x sets `additionalProperties: false` at the schema root and rejects those values with a `values-schema-violation`, so the App never reached `deployed` and the test timed out.

Install `hello-world` via a Flux `HelmRelease` instead (no cluster-values injection), mirroring how `cluster-test-suites` installs it. An explicit release name keeps the rendered Deployment name deterministic for the lookup.