### PR TITLE
fix: default bundle App to the Release-pinned version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bundle suites (`InAppBundle`): default the parent bundle App to the version pinned by the cluster's Release instead of always installing the latest published bundle. An explicit `E2E_OVERRIDE_VERSIONS` entry for the bundle takes precedence, and if the bundle is not part of the Release the latest published version is used as a fallback. This stops app suites from incidentally running a bundle version that is ahead of (and potentially incompatible with) the release under test — e.g. `security-bundle` v2.x's HelmRelease-based sub-apps on a cluster that still expects App CRs.
+
 ### Fixed
 
 - `basic` e2e suite: install the `hello-world` test app via a Flux `HelmRelease` instead of an `App` CR. The App CR path injects the cluster-values, which `hello-world` v3.x rejects (`additionalProperties: false` at the schema root) with a `values-schema-violation`, so the install never completed. This mirrors how `cluster-test-suites` installs `hello-world`.

--- a/docs/WRITING_TESTS.md
+++ b/docs/WRITING_TESTS.md
@@ -147,7 +147,21 @@ suite.New().
   ...etc...
 ```
 
-When testing within a bundle, the test framework will use the latest released version of the bundle App and override the version of the App being tested within the bundle values.
+When testing within a bundle, the framework installs the **parent bundle App at the version pinned by the cluster's Release** and overrides the version of the App being tested (the child) within the bundle values. The child App under test still comes from `E2E_APP_VERSION` (e.g. your PR build), so your changes are exercised _inside_ the bundle as it is actually shipped.
+
+### Bundle version resolution
+
+The parent bundle's version is resolved in the following order:
+
+1. An explicit `E2E_OVERRIDE_VERSIONS` entry for the bundle (e.g. `E2E_OVERRIDE_VERSIONS=security-bundle=2.0.0`, optionally `name=version:catalog`) — highest priority.
+2. The version pinned for the bundle in the cluster's Release — the default.
+3. The latest published bundle release — used only as a fallback when the bundle is not part of the Release.
+
+> [!NOTE]
+> The bundle defaults to the **Release-pinned** version rather than the bundle's newest GitHub release. This stops a suite from incidentally running a bundle version that is ahead of (and potentially incompatible with) the release under test — for example a bundle that has moved its sub-apps to Flux `HelmRelease`s while the cluster still expects `App` CRs. If you specifically need a different bundle version, set it via `E2E_OVERRIDE_VERSIONS`.
+
+> [!TIP]
+> This only applies when you install a child App _through_ a bundle via `InAppBundle`. A bundle repository that tests **itself** (e.g. [security-bundle](https://github.com/giantswarm/security-bundle/tree/main/tests/e2e/suites/basic)) installs the bundle as the top-level App under test (driven by `E2E_APP_VERSION`) and does not call `InAppBundle`, so this resolution does not apply to it — its own PR build is tested as expected.
 
 If the bundle App is also a default app please make sure to also read the [Testing Default Apps](#testing-default-apps) section below.
 

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -377,13 +377,11 @@ func (s *suite) Run(t *testing.T, suiteName string) {
 		}
 
 		if s.inBundleApp != "" {
-			bundleVersion, err := application.GetLatestAppVersion(s.inBundleApp)
-			Expect(err).ToNot(HaveOccurred())
-			bundleVersion = strings.TrimPrefix(bundleVersion, "v")
+			bundleVersion, bundleCatalog := s.resolveBundleVersion(cluster)
 
 			bundleAppName := fmt.Sprintf("%s-%s", cluster.Name, s.inBundleApp)
 			bundleApp := application.New(bundleAppName, s.inBundleApp).
-				WithCatalog(s.appCatalog).
+				WithCatalog(bundleCatalog).
 				WithOrganization(*cluster.Organization).
 				WithClusterName(cluster.Name).
 				WithVersion(bundleVersion).
@@ -392,7 +390,7 @@ func (s *suite) Run(t *testing.T, suiteName string) {
 				WithInCluster(true)
 
 			// Replace app with bundle app that has version of child App set
-			bundleApp, err = bundles.OverrideChildApp(bundleApp, app, s.inBundleAppOverrideType)
+			bundleApp, err := bundles.OverrideChildApp(bundleApp, app, s.inBundleAppOverrideType)
 			Expect(err).NotTo(HaveOccurred())
 			state.SetBundleApplication(bundleApp)
 
@@ -734,6 +732,69 @@ func getInstallApp() *application.Application {
 		return bundleApp
 	}
 	return state.GetApplication()
+}
+
+// resolveBundleVersion determines the version and catalog of the bundle App to install.
+//
+// By default the bundle is pinned to the version shipped by the cluster's Release, so suites
+// that install an app via a bundle test it as released instead of incidentally bumping the
+// bundle to the latest published version (which may be ahead of any release and incompatible).
+// An explicit override via E2E_OVERRIDE_VERSIONS for the bundle takes precedence. If the bundle
+// is not part of the Release, it falls back to the latest published bundle version.
+func (s *suite) resolveBundleVersion(cluster *application.Cluster) (version string, catalog string) {
+	// 1. Explicit override via E2E_OVERRIDE_VERSIONS (e.g. when testing a bundle's own build).
+	if v, c, ok := overrideVersionFor(s.inBundleApp); ok {
+		if c == "" {
+			c = s.appCatalog
+		}
+		logger.Log("Using overridden bundle version for '%s': %s (catalog: %s)", s.inBundleApp, v, c)
+		return strings.TrimPrefix(v, "v"), c
+	}
+
+	// 2. Version pinned by the cluster's Release.
+	if release, err := cluster.GetRelease(); err == nil && release != nil {
+		for _, releaseApp := range release.Spec.Apps {
+			if releaseApp.Name == s.inBundleApp {
+				c := releaseApp.Catalog
+				if c == "" {
+					c = s.appCatalog
+				}
+				logger.Log("Using Release-pinned bundle version for '%s': %s (catalog: %s)", s.inBundleApp, releaseApp.Version, c)
+				return strings.TrimPrefix(releaseApp.Version, "v"), c
+			}
+		}
+	}
+
+	// 3. Fallback: latest published bundle release.
+	latest, err := application.GetLatestAppVersion(s.inBundleApp)
+	Expect(err).ToNot(HaveOccurred())
+	logger.Log("Bundle '%s' is not pinned in the Release; falling back to latest published version: %s", s.inBundleApp, latest)
+	return strings.TrimPrefix(latest, "v"), s.appCatalog
+}
+
+// overrideVersionFor parses the E2E_OVERRIDE_VERSIONS environment variable and returns the
+// version (and optional catalog) requested for the given app, if any. The format mirrors the
+// one used by clustertest: a comma separated list of `app=version` or `app=version:catalog`.
+func overrideVersionFor(appName string) (version string, catalog string, ok bool) {
+	overrides := os.Getenv("E2E_OVERRIDE_VERSIONS")
+	if overrides == "" {
+		return "", "", false
+	}
+	for _, pair := range strings.Split(overrides, ",") {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(parts[0]), appName) {
+			continue
+		}
+		value := strings.TrimSpace(parts[1])
+		if idx := strings.LastIndex(value, ":"); idx != -1 {
+			return strings.TrimSpace(value[:idx]), strings.TrimSpace(value[idx+1:]), true
+		}
+		return value, "", true
+	}
+	return "", "", false
 }
 
 func isEphemeralTestMC() bool {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36860

InAppBundle suites always installed the latest published bundle via `GetLatestAppVersion`. For `security-bundle` that resolves to v2.0.0, which deploys its sub-apps as Flux HelmReleases — a version not yet shipped in any platform release, and incompatible with the App-CR readiness/dependency mechanics the cluster still uses. The `defaultbundleapp` suite then hangs in `BeforeSuite` waiting for default apps to become ready.

Default the bundle to the version pinned by the cluster's Release (e.g. `security-bundle` v1.17.x, App-CR based). An explicit `E2E_OVERRIDE_VERSIONS` entry for the bundle still takes precedence, and we fall back to the latest published version only when the bundle is not part of the Release.

Mirrors the clustertest v5.4.0 change that stopped incidentally bumping the provider cluster app to its latest version.