### PR TITLE
fix(client): log helmrelease status while waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Log HelmRelease status while waiting for readiness and version, matching the existing App CR logging. Readiness checks now reuse the `helmrelease` wait helpers from `clustertest` and report every HelmRelease instead of stopping at the first one that isn't ready.
+
 ## [5.2.2] - 2026-07-26
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -181,6 +181,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v4 v4.2.3 // indirect
 	k8s.io/apiextensions-apiserver v0.36.3 // indirect
 	k8s.io/apiserver v0.36.3 // indirect

--- a/pkg/client/helmrelease.go
+++ b/pkg/client/helmrelease.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/giantswarm/clustertest/v5/pkg/helmrelease"
 	"github.com/giantswarm/clustertest/v5/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -133,53 +134,28 @@ func InstallHelmRelease(ctx context.Context, cfg HelmReleaseConfig) {
 }
 
 // IsHelmReleaseReady checks if a HelmRelease has the Ready condition set to True.
+// The current status is logged on each call, mirroring the App CR wait conditions.
 func IsHelmReleaseReady(ctx context.Context, name, namespace string) (bool, error) {
-	hr := &helmv2.HelmRelease{}
-	err := state.GetFramework().MC().Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, hr)
+	ready, err := helmrelease.IsHelmReleaseReady(ctx, state.GetFramework().MC(), name, namespace)()
 	if err != nil {
 		if errors.IsNotFound(err) {
+			logger.Log("HelmRelease '%s/%s' not found yet", namespace, name)
 			return false, nil
 		}
 		return false, err
 	}
-
-	for _, condition := range hr.Status.Conditions {
-		if condition.Type == "Ready" {
-			return condition.Status == metav1.ConditionTrue, nil
-		}
-	}
-
-	return false, nil
+	return ready, nil
 }
 
 // IsAllHelmReleasesReady returns a check function for use with Gomega's Eventually
 // that polls the given list of HelmReleases and returns true once all of them
 // have a Ready=True condition. Its signature mirrors wait.IsAllAppDeployed so
 // call-sites can use either one interchangeably.
+// Every HelmRelease is checked and logged on each poll, so a stuck release is visible.
 func IsAllHelmReleasesReady(ctx context.Context, c cr.Client, helmReleases []types.NamespacedName) func() (bool, error) {
+	areAllReady := helmrelease.AreAllReady(ctx, c, helmReleases)
 	return func() (bool, error) {
-		for _, nn := range helmReleases {
-			hr := &helmv2.HelmRelease{}
-			err := c.Get(ctx, nn, hr)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return false, nil
-				}
-				return false, err
-			}
-
-			ready := false
-			for _, condition := range hr.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == metav1.ConditionTrue {
-					ready = true
-					break
-				}
-			}
-			if !ready {
-				return false, nil
-			}
-		}
-		return true, nil
+		return areAllReady() == nil, nil
 	}
 }
 
@@ -196,7 +172,7 @@ func IsHelmReleaseVersion(ctx context.Context, name, namespace, version string) 
 
 	// Check spec.chart if using HelmRepository source
 	if hr.Spec.Chart != nil {
-		return hr.Spec.Chart.Spec.Version == version, nil
+		return logHelmReleaseVersion(name, version, hr.Spec.Chart.Spec.Version), nil
 	}
 
 	// For OCIRepository sources, check the last attempted revision in status.
@@ -204,10 +180,21 @@ func IsHelmReleaseVersion(ctx context.Context, name, namespace, version string) 
 	// version may carry a v prefix, so normalise both sides before comparing.
 	if hr.Status.LastAttemptedRevision != "" {
 		rev := strings.SplitN(hr.Status.LastAttemptedRevision, "+", 2)[0]
-		return rev == strings.TrimPrefix(version, "v"), nil
+		return logHelmReleaseVersion(name, strings.TrimPrefix(version, "v"), rev), nil
 	}
 
+	logger.Log("HelmRelease version for '%s' is not yet known: expectedVersion='%s'", name, version)
 	return false, nil
+}
+
+// logHelmReleaseVersion logs the version comparison and reports whether it matches.
+func logHelmReleaseVersion(name, expectedVersion, actualVersion string) bool {
+	if expectedVersion == actualVersion {
+		logger.Log("HelmRelease version for '%s' is as expected: expectedVersion='%s' actualVersion='%s'", name, expectedVersion, actualVersion)
+		return true
+	}
+	logger.Log("HelmRelease version for '%s' is not yet as expected: expectedVersion='%s' actualVersion='%s'", name, expectedVersion, actualVersion)
+	return false
 }
 
 // DeleteHelmRelease deletes a HelmRelease CR and its associated values Secret if present.


### PR DESCRIPTION
## Why

When waiting for apps to become ready, App CRs log a line per poll (`App status for '...' is as expected: ...`), but HelmReleases logged nothing. A run stuck on a HelmRelease gave no hint about which one or why.

The two branches of the wait in `pkg/suite/suite.go` used different helpers: the App branch calls clustertest's `wait.IsAllAppDeployed`, which logs each App, while the HelmRelease branch called a local re-implementation in `pkg/client/helmrelease.go` with no logging that also returned at the first non-ready release. The install path (`IsHelmReleaseReady`, `IsHelmReleaseVersion`) was silent for the same reason.

## What

- `IsHelmReleaseReady` and `IsAllHelmReleasesReady` now delegate to the `helmrelease` wait helpers already available in `clustertest`, which log `HelmRelease '<name>' is Ready` / `... not yet ready: <reason> - <message>`.
- All HelmReleases are checked and logged on every poll instead of bailing out at the first one that is not ready.
- `IsHelmReleaseVersion` logs expected vs actual chart version.
- Exported signatures are unchanged, so call sites and downstream suites keep working.

## Testing

`go build`, `go vet`, `go test ./...` and `golangci-lint run` pass. There are no unit tests for `pkg/client`, so the log output itself needs a real suite run against a cluster that deploys default apps as HelmReleases.